### PR TITLE
Use Action default token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Go Snapshot Action
 
-An action that creates a dependency submission using `go mod graph`.
+An Action that creates a dependency submission using `go mod graph`.
 
-To configure, you'll need to provide a GitHub token. Additional optional inputs include: `detector-name`, `detector-url`, `detector-version`, and `metadata` - a JSON of max eight keys to provide with the snapshot. 
+Optional inputs for the Action include: `detector-name`, `detector-url`, `detector-version`, and `metadata` - a JSON of max eight keys to provide with the snapshot.
 
 ```
 name: Run snapshot action
-uses: ./go-snapshot-action
+uses: @dsp-testing/go-snapshot-action
 with:
-    token: ${{ secrets.GITHUB_TOKEN }}
+    # All of the below have defaults, but can be overriden manually
     detector-name: go snapshot action
     detector-url: ${{ github.server_url }}/${{ github.repository }}
     detector-version: 1.0.0

--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,9 @@ description: 'Detects go dependencies in projects using go mod graph utility'
 author: 'lorenanicole'
 inputs:
   token:
-    required: true
-    description: 'Personal access token for the GitHub API'
+    description: "GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner"
+    required: false
+    default: ${{ github.token }}
   detector-name: 
     required: false
     description: 'Name of the detector running the go action e.g. Go Snapshot Detector'


### PR DESCRIPTION
Actions provide an authorization token by default. This is provided both by the `github.token` template variable and by the environment variable `GITHUB_TOKEN`. This changes the `token` input to use this default token.

With this specified, it is not necessary to provide a PAT in `secrets`.